### PR TITLE
Refactor: Disable carousel autoplay and remove controls

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -105,8 +105,6 @@ const AnimatedSection = ({ children, className, delay = 0 }) => {
 export default function LandingPage() {
   const [activeTestimonial, setActiveTestimonial] = useState(0)
   const [displayedTestimonials, setDisplayedTestimonials] = useState([])
-  // State for managing testimonial carousel autoplay pause/resume for accessibility
-  const [isTestimonialAutoplayPaused, setIsTestimonialAutoplayPaused] = useState(false)
   const allTestimonials = [
     {
       name: "Mariana",
@@ -189,16 +187,8 @@ export default function LandingPage() {
     setDisplayedTestimonials(randomTestimonials)
   }, [])
 
-  useEffect(() => {
-    if (displayedTestimonials.length === 0 || isTestimonialAutoplayPaused) {
-      return // Do nothing if paused or no testimonials
-    }
-
-    const interval = setInterval(() => {
-      setActiveTestimonial((prev) => (prev + 1) % displayedTestimonials.length)
-    }, 5000)
-    return () => clearInterval(interval)
-  }, [displayedTestimonials.length, isTestimonialAutoplayPaused]) // Add isTestimonialAutoplayPaused to dependency array
+  // useEffect for autoplay was here - removed to disable autoplay.
+  // Navigation is now manual via dot indicators.
 
   return (
     <div className="flex min-h-screen flex-col bg-background text-foreground overflow-x-hidden">
@@ -604,16 +594,6 @@ export default function LandingPage() {
                     aria-label={`Ver depoimento ${index + 1}`}
                   />
                 ))}
-              </div>
-              {/* Pause/Resume button for testimonial carousel accessibility */}
-              <div className="mt-4 text-center">
-                <button
-                  onClick={() => setIsTestimonialAutoplayPaused((prev) => !prev)}
-                  className="text-sm text-muted-foreground underline hover:text-primary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 p-2"
-                  aria-live="polite" // Announce changes to screen readers
-                >
-                  {isTestimonialAutoplayPaused ? "Retomar Rolagem Automática" : "Pausar Rolagem Automática"}
-                </button>
               </div>
             </div>
 

--- a/components/module-carousel.tsx
+++ b/components/module-carousel.tsx
@@ -48,7 +48,6 @@ interface ModuleCarouselProps {
 export function ModuleCarousel({ modules }: ModuleCarouselProps) {
   const [currentIndex, setCurrentIndex] = useState(0)
   const [visibleCount, setVisibleCount] = useState(3)
-  const [autoplay, setAutoplay] = useState(true)
   const totalModules = modules.length
 
   // Determine how many cards to show based on screen size
@@ -68,30 +67,16 @@ export function ModuleCarousel({ modules }: ModuleCarouselProps) {
     return () => window.removeEventListener("resize", handleResize)
   }, [])
 
-  // Autoplay functionality
-  useEffect(() => {
-    if (!autoplay) return
-
-    const interval = setInterval(() => {
-      setCurrentIndex((prevIndex) => (prevIndex + 1) % (totalModules - visibleCount + 1))
-    }, 5000)
-
-    return () => clearInterval(interval)
-  }, [autoplay, totalModules, visibleCount])
-
   const handleNext = useCallback(() => {
-    setAutoplay(false)
     setCurrentIndex((prevIndex) => Math.min(prevIndex + 1, totalModules - visibleCount))
   }, [totalModules, visibleCount])
 
   const handlePrev = useCallback(() => {
-    setAutoplay(false)
     setCurrentIndex((prevIndex) => Math.max(prevIndex - 1, 0))
   }, [])
 
   const handleDotClick = useCallback(
     (index: number) => {
-      setAutoplay(false)
       setCurrentIndex(Math.min(index, totalModules - visibleCount))
     },
     [totalModules, visibleCount],
@@ -160,17 +145,7 @@ export function ModuleCarousel({ modules }: ModuleCarouselProps) {
           />
         ))}
       </div>
-
-      {/* Pause/Resume button for module carousel autoplay accessibility */}
-      <div className="mt-4 text-center">
-        <button
-          onClick={() => setAutoplay(prev => !prev)}
-          className="text-sm text-muted-foreground underline hover:text-primary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 p-2"
-          aria-live="polite" // Announce changes to screen readers
-        >
-          {autoplay ? "Pausar Rolagem Automática" : "Iniciar Rolagem Automática"}
-        </button>
-      </div>
+      {/* Pause/Resume button removed as autoplay is disabled */}
     </div>
   )
 }


### PR DESCRIPTION
This commit updates the behavior of the Testimonial and Module carousels based on your feedback. Autoplay functionality has been removed from both carousels.

Changes:

1.  **Testimonial Carousel (`app/page.tsx`)**:
    *   Removed the `isTestimonialAutoplayPaused` state and the associated UI button for toggling autoplay.
    *   Disabled the automatic timed advancement of testimonials by removing the `setInterval` logic. Navigation is now exclusively manual using the dot indicators.

2.  **Module Carousel (`components/module-carousel.tsx`)**:
    *   Removed the `autoplay` state variable and the UI button for toggling autoplay.
    *   Deleted the `useEffect` hook responsible for the autoplay interval.
    *   Removed calls to `setAutoplay(false)` from manual navigation handlers (`handleNext`, `handlePrev`, `handleDotClick`) as the `autoplay` state no longer exists. Navigation is now exclusively manual using arrow buttons and dot indicators.

Both carousels will now load in a static (paused) state, requiring your interaction for navigation. This change simplifies the components and aligns with the specified requirements.